### PR TITLE
Add announcement tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ nohup.out
 env
 archive
 booking/bookings.json
+announcements/announcements.json

--- a/announcements/announcements.py
+++ b/announcements/announcements.py
@@ -1,0 +1,29 @@
+from helper.json_helper import readAnnouncements, getMemberName
+
+
+"""
+Builds the shame message to send everyday
+"""
+
+
+def getShameMessage():
+    shameMessage = "**WALL OF SHAME**\n"
+    announces = readAnnouncements()
+    names = set()
+    empty = True
+    for messageId in announces:
+        if (announces[messageId]["enabled"]):
+            shameMessage += announces[messageId]["url"] + "\n```"
+            for memberId in announces[messageId]["toReact"]:
+                names.add(getMemberName(memberId))
+                empty = False
+
+            for member in sorted(list(names)):
+                shameMessage += member + ", "
+
+            names = set()
+            shameMessage = shameMessage[:-2] + "```\n"
+    if (empty):
+        return ""
+
+    return shameMessage

--- a/booking/bookingEmbed.py
+++ b/booking/bookingEmbed.py
@@ -13,7 +13,7 @@ class BookingEmbed:
 
     def __init__(self, ctx):
         self.ctx = ctx
-        self.author = getMemberName(ctx.author)
+        self.author = getMemberName(ctx.author.id)
         self.booking = Booking()
         self.message = None
 

--- a/helper/json_helper.py
+++ b/helper/json_helper.py
@@ -1,6 +1,7 @@
 import json
 from helper.global_vars import *
 
+
 def getJSON(key):
     with open(key, "r") as json_file:
         bookings = json.load(json_file)
@@ -16,10 +17,20 @@ def getMembers():
     return getJSON("env/members.json")
 
 
+def getAllMemberIds():
+    members = getMembers()
+    allMembers = set()
+    for role in members:
+        for name in members[role]:
+            allMembers.add(name)
+
+    return list(allMembers)
+
+
 def getMemberName(user):
     members = getMembers()
     for role in members:
-        userId = str(user.id)
+        userId = str(user)
         if userId in members[role]:
             return members[role][userId]
 
@@ -32,3 +43,10 @@ def readBookings():
 
 def writeBookings(bookings):
     setJSON("booking/bookings.json", bookings)
+
+def readAnnouncements():
+    return getJSON("announcements/announcements.json")
+
+
+def writeAnnouncements(announcements):
+    setJSON("announcements/announcements.json", announcements)

--- a/kong.py
+++ b/kong.py
@@ -2,10 +2,14 @@ from discord.ext import commands, tasks
 from discord.utils import get
 import discord
 
+from datetime import datetime
+from helper.json_helper import getJSON, readAnnouncements, writeAnnouncements, getAllMemberIds
 from helper.time_helper import toReadableTime
 from helper.global_vars import *
 from booking.booking import getCurrentBooking
 from booking.bookingEmbed import BookingEmbed
+from announcements.announcements import getShameMessage
+
 from misc_commands.valorant import createValorantGame
 import asyncio
 
@@ -14,6 +18,9 @@ import asyncio
 intents = discord.Intents.all()
 client = commands.Bot(
     intents=intents, command_prefix='kong ', help_command=None)
+
+
+env = getJSON("env/env.json")
 
 
 async def updateStatus():
@@ -38,6 +45,23 @@ async def updateStatus():
         await asyncio.sleep(10)
 
 
+async def wallOfShame():
+    # post at 11 AM everyday
+    postedToday = False
+    while True:
+        currentTime = datetime.now()
+        currentHour = currentTime.hour
+        if (not postedToday and currentHour == 11):
+            shameMessage = getShameMessage()
+            if len(shameMessage) > 0:
+                await client.get_channel(env["ANNOUNCEMENT_CHANNEL"]).send(shameMessage)
+
+            postedToday = True
+        elif (currentHour < 11):
+            postedToday = False
+        await asyncio.sleep(900)
+
+
 @ client.event
 async def on_ready():
     print('Kong is logged in')
@@ -47,7 +71,7 @@ async def on_ready():
     except Exception as e:
         print(e)
     asyncio.ensure_future(updateStatus())
-
+    asyncio.ensure_future(wallOfShame())
 # BADGE
 
 
@@ -96,5 +120,66 @@ async def valorant(ctx):
 @ client.event
 async def on_message(message):
     await client.process_commands(message)
+
+
+@ client.event
+async def on_raw_reaction_add(payload):
+    if (payload.emoji.name == "kongannounce"):
+        try:
+            announces = readAnnouncements()
+        except:
+            announces = {}
+
+        messageId = str(payload.message_id)
+        # message already exists - unsoft delete it
+        if (messageId in announces):
+            announces[messageId]["enabled"] = True
+        else:
+            members = getAllMemberIds()
+            # get discord msg object
+            channel_id = payload.channel_id
+            guild = client.get_guild(payload.guild_id)
+            channel = guild.get_channel(channel_id)
+            discordMsg = await channel.fetch_message(messageId)
+
+            # build announcement object
+            announces[messageId] = {
+                "enabled": True, "toReact": members, "url": discordMsg.jump_url}
+
+            await discordMsg.add_reaction("✅")
+            await discordMsg.add_reaction("❌")
+
+        writeAnnouncements(announces)
+
+    # only valid reactions to announcement is checkmark and cross
+    if ((payload.emoji.name == "✅" or payload.emoji.name == "❌") and payload.user_id != env["KONG_ID"]):
+        announces = readAnnouncements()
+        messageId = str(payload.message_id)
+        if (messageId in announces):
+            try:
+                # remove the user from users that need to react
+                announces[messageId]["toReact"].remove(str(payload.user_id))
+                writeAnnouncements(announces)
+            except:
+                print("Error adding reaction")
+
+
+@ client.event
+async def on_raw_reaction_remove(payload):
+    if (payload.emoji.name == "kongannounce"):
+        # soft delete announcement object in case user wants to re-enable
+        announces = readAnnouncements()
+        messageId = str(payload.message_id)
+        if (messageId in announces):
+            announces[messageId]["enabled"] = False
+            writeAnnouncements(announces)
+
+    if (payload.emoji.name == "✅" or payload.emoji.name == "❌"):
+        # add user back to users that need to react if they unreact
+        announces = readAnnouncements()
+        messageId = str(payload.message_id)
+        if (messageId in announces):
+            announces[messageId]["toReact"].append(str(payload.user_id))
+            writeAnnouncements(announces)
 
 client.run(TOKEN)

--- a/misc_commands/valorant.py
+++ b/misc_commands/valorant.py
@@ -1,3 +1,6 @@
+import random
+
+
 async def createValorantGame(ctx):
     '''Creates a valorant lobby with the users in the call'''
     try:
@@ -20,7 +23,8 @@ async def createValorantGame(ctx):
                 addToAttackers = True
 
         # choose a map
-        lobbyMap = random.choice(["Bind", "Haven", "Split","Ascent","Icebox","Breeze","Fracture","Pearl", "Lotus"])
+        lobbyMap = random.choice(
+            ["Bind", "Haven", "Split", "Ascent", "Icebox", "Breeze", "Fracture", "Pearl", "Lotus"])
 
         # build output message
         lobby = "**Valorant Custom Lobby**\nMap: " + lobbyMap + "\nAttackers: "
@@ -31,7 +35,7 @@ async def createValorantGame(ctx):
         for member in defenders:
             lobby += member + ", "
         lobby = lobby[:-2]
-        
+
         await ctx.send(lobby)
-    except :
+    except:
         await ctx.send("Please join a call")


### PR DESCRIPTION
When you tag an announcement with the "kongannounce" emoji, the bot will react to that same announcement with ✅ or ❌. The bot will then keep track who has emoted on the announcement. For example "Who's free to volunteer at our event", the bot will track who emotes with a ✅ or ❌. To stop keeping track of the announcement, simply remove the "kongannounce" reaction. Since it's implemented with soft deletes, you can always react again and all the data will be saved.

People who did not emote will be on the "WALL OF SHAME" which is posted everyday at 11AM. It'll send a quick link to the announcement and display the people who didn't emote. This keeps everyone accountable. We can get replies much quicker and also poke fun at members

Reacting
![image](https://github.com/tmucscu/kong/assets/71723813/0c96d833-1101-4eb0-a540-eba481789aeb)

Wall of Shame
![image](https://github.com/tmucscu/kong/assets/71723813/129769af-4d8f-4318-afb6-e3d5e145121a)


